### PR TITLE
태그 유사도 계산 키 불일치 수정

### DIFF
--- a/src/main/java/com/monsoon/seedflowplus/domain/product/service/ProductSimilarityService.java
+++ b/src/main/java/com/monsoon/seedflowplus/domain/product/service/ProductSimilarityService.java
@@ -21,13 +21,22 @@ import java.util.Objects;
 @Transactional(readOnly = true)
 public class ProductSimilarityService {
 
-    // 태그 카테고리별 가중치 (합계 = 1.0)
+    // 태그 카테고리별 가중치 - DB 저장 키(한글) 기준
     private static final Map<String, Double> TAG_CATEGORY_WEIGHTS = Map.of(
-            "env",    0.30,  // 재배환경
-            "res",    0.25,  // 내병성
-            "growth", 0.20,  // 생육 및 숙기
-            "quality",0.15,  // 과실 품질
-            "conv",   0.10   // 재배 편의성
+            "재배환경",   0.30,
+            "내병성",     0.25,
+            "생육및숙기", 0.20,
+            "과실품질",   0.15,
+            "재배편의성", 0.10
+    );
+
+    // 프론트 체크박스 키(영문) → DB 태그 키(한글) 매핑
+    private static final Map<String, String> CRITERIA_KEY_MAP = Map.of(
+            "env",    "재배환경",
+            "res",    "내병성",
+            "growth", "생육및숙기",
+            "quality","과실품질",
+            "conv",   "재배편의성"
     );
 
     // 유사도 전체 가중치 (같은 카테고리 내에서만 비교하므로 카테고리 가중치 제거)
@@ -68,12 +77,13 @@ public class ProductSimilarityService {
         int normalizedLimit     = (limit <= 0) ? DEFAULT_LIMIT : Math.min(limit, MAX_LIMIT);
         int normalizedThreshold = Math.max(0, Math.min(threshold, 100));
 
-        // criteria 유효성 검증 - 알 수 없는 키 필터링, 전부 무효 시 전체 카테고리로 fallback
+        // criteria 영문 키 → 한글 변환 후 유효성 검증, 전부 무효 시 전체 카테고리로 fallback
         Set<String> validatedCriteria = (criteria == null || criteria.isEmpty())
                 ? Set.of()
                 : criteria.stream()
                 .filter(Objects::nonNull)
                 .map(String::trim)
+                .map(key -> CRITERIA_KEY_MAP.getOrDefault(key, key)) // 영문이면 한글로 변환
                 .filter(TAG_CATEGORY_WEIGHTS::containsKey)
                 .collect(Collectors.toSet());
 


### PR DESCRIPTION
## 변경 사항
- TAG_CATEGORY_WEIGHTS 키를 영문 → 한글(DB 저장값 기준)로 변경
- 프론트 영문 criteria 키(env, res 등) → 한글로 변환하는 CRITERIA_KEY_MAP 추가
- 기존 영문 키 불일치로 태그 유사도가 0으로 계산되던 문제 해결

## 작업 내용
- [ ] 기능 구현
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 테스트 추가/수정
- [ ] 문서 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 변수명 변경)

## 체크리스트
- [x] 중요!! : run했을 때 멈추지 않고 돌아가는가
- [x] Push 전 pull dev 했는가
- [ ] 불필요한 코드/주석이 없는가

## 참고 사항(생략 가능)
- 리뷰어가 알면 좋은 내용 (스크린샷, 로그, 설계 설명 등)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **리팩토링**
  * 상품 유사도 평가 시스템의 기준 검증 로직을 개선했습니다.
  * 평가 카테고리 식별자 처리 방식을 최적화하여 시스템 안정성을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->