### PR TITLE
거래처 거래 요약 조회 api 추가

### DIFF
--- a/src/main/java/com/monsoon/seedflowplus/domain/sales/order/controller/OrderController.java
+++ b/src/main/java/com/monsoon/seedflowplus/domain/sales/order/controller/OrderController.java
@@ -7,6 +7,7 @@ import com.monsoon.seedflowplus.domain.sales.order.dto.request.OrderCreateReques
 import com.monsoon.seedflowplus.domain.sales.order.dto.response.OrderCancelResponse;
 import com.monsoon.seedflowplus.domain.sales.order.dto.response.OrderListResponse;
 import com.monsoon.seedflowplus.domain.sales.order.dto.response.OrderResponse;
+import com.monsoon.seedflowplus.domain.sales.order.dto.response.OrderTradeSummaryResponse;
 import com.monsoon.seedflowplus.domain.sales.order.service.OrderService;
 import com.monsoon.seedflowplus.infra.security.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
@@ -72,5 +73,16 @@ public class OrderController {
             throw new CoreException(ErrorType.UNAUTHORIZED);
         }
         return ApiResult.success(orderService.confirmOrder(orderId, userDetails));
+    }
+
+    @Operation(
+            summary = "거래처 거래 요약 조회",
+            description = "영업사원/관리자가 특정 거래처의 이번달 거래 요약 및 여신 정보를 조회합니다."
+    )
+    @GetMapping("/clients/{clientId}/trade-summary")
+    public ApiResult<OrderTradeSummaryResponse> getTradeSummary(
+            @PathVariable Long clientId
+    ) {
+        return ApiResult.success(orderService.getTradeSummary(clientId));
     }
 }

--- a/src/main/java/com/monsoon/seedflowplus/domain/sales/order/dto/response/OrderTradeSummaryResponse.java
+++ b/src/main/java/com/monsoon/seedflowplus/domain/sales/order/dto/response/OrderTradeSummaryResponse.java
@@ -1,0 +1,40 @@
+package com.monsoon.seedflowplus.domain.sales.order.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+@Getter
+@Builder
+@Schema(description = "거래처 거래 요약 응답 (영업사원/관리자 전용)")
+public class OrderTradeSummaryResponse {
+
+    @Schema(description = "이번달 거래 요약")
+    private ThisMonth thisMonth;
+
+    @Schema(description = "여신 한도", example = "50000000")
+    private BigDecimal totalCredit;
+
+    @Schema(description = "현재 미수금 (사용 여신)", example = "12000000")
+    private BigDecimal usedCredit;
+
+    @Schema(description = "잔여 여신 (여신 한도 - 미수금)", example = "38000000")
+    private BigDecimal remainingCredit;
+
+    @Getter
+    @Builder
+    @Schema(description = "이번달 주문 집계")
+    public static class ThisMonth {
+
+        @Schema(description = "이번달 총 주문 금액", example = "5500000")
+        private BigDecimal totalAmount;
+
+        @Schema(description = "진행 중인 주문 건수 (PENDING)", example = "3")
+        private long inProgressCount;
+
+        @Schema(description = "완료된 주문 건수 (CONFIRMED)", example = "2")
+        private long completedCount;
+    }
+}

--- a/src/main/java/com/monsoon/seedflowplus/domain/sales/order/repository/OrderHeaderRepository.java
+++ b/src/main/java/com/monsoon/seedflowplus/domain/sales/order/repository/OrderHeaderRepository.java
@@ -5,7 +5,10 @@ import com.monsoon.seedflowplus.domain.sales.order.entity.OrderHeader;
 import com.monsoon.seedflowplus.domain.sales.order.entity.OrderStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
 
@@ -32,4 +35,39 @@ public interface OrderHeaderRepository extends JpaRepository<OrderHeader, Long> 
 
     // 거래처 존재 여부 확인 (스코어링용)
     boolean existsByClient(Client client);
+
+    /**
+     * 특정 거래처의 이번달 취소 제외 주문 총액 합산
+     */
+    @Query("""
+    SELECT COALESCE(SUM(oh.totalAmount), 0)
+    FROM OrderHeader oh
+    WHERE oh.client.id = :clientId
+      AND oh.status <> 'CANCELED'
+      AND oh.createdAt >= :startOfMonth
+      AND oh.createdAt < :startOfNextMonth
+""")
+    BigDecimal sumThisMonthTotalAmount(
+            @Param("clientId") Long clientId,
+            @Param("startOfMonth") LocalDateTime startOfMonth,
+            @Param("startOfNextMonth") LocalDateTime startOfNextMonth
+    );
+
+    /**
+     * 특정 거래처의 이번달 특정 상태 주문 건수
+     */
+    @Query("""
+        SELECT COUNT(oh)
+        FROM OrderHeader oh
+        WHERE oh.client.id = :clientId
+          AND oh.status = :status
+          AND oh.createdAt >= :startOfMonth
+          AND oh.createdAt < :startOfNextMonth
+    """)
+    long countThisMonthByStatus(
+            @Param("clientId") Long clientId,
+            @Param("status") OrderStatus status,
+            @Param("startOfMonth") LocalDateTime startOfMonth,
+            @Param("startOfNextMonth") LocalDateTime startOfNextMonth
+    );
 }

--- a/src/main/java/com/monsoon/seedflowplus/domain/sales/order/service/OrderService.java
+++ b/src/main/java/com/monsoon/seedflowplus/domain/sales/order/service/OrderService.java
@@ -20,10 +20,7 @@ import com.monsoon.seedflowplus.domain.sales.contract.repository.ContractDetailR
 import com.monsoon.seedflowplus.domain.sales.contract.repository.ContractRepository;
 import com.monsoon.seedflowplus.domain.sales.order.dto.request.OrderCreateRequest;
 import com.monsoon.seedflowplus.domain.sales.order.dto.request.OrderDetailRequest;
-import com.monsoon.seedflowplus.domain.sales.order.dto.response.OrderCancelResponse;
-import com.monsoon.seedflowplus.domain.sales.order.dto.response.OrderDetailResponse;
-import com.monsoon.seedflowplus.domain.sales.order.dto.response.OrderListResponse;
-import com.monsoon.seedflowplus.domain.sales.order.dto.response.OrderResponse;
+import com.monsoon.seedflowplus.domain.sales.order.dto.response.*;
 import com.monsoon.seedflowplus.domain.sales.order.entity.OrderDetail;
 import com.monsoon.seedflowplus.domain.sales.order.entity.OrderHeader;
 import com.monsoon.seedflowplus.domain.sales.order.entity.OrderStatus;
@@ -36,6 +33,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 
@@ -323,6 +321,55 @@ public class OrderService {
             throw new CoreException(ErrorType.UNAUTHORIZED);
         }
         return actorId;
+    }
+
+    // ----------------------------------------------------------------
+    // 거래처 거래 요약 조회 (영업사원/관리자 - 거래처 상세 페이지)
+    // ----------------------------------------------------------------
+
+    /**
+     * 특정 거래처의 이번달 거래 요약 + 여신 정보를 조회합니다.
+     * - 영업사원/관리자만 호출 가능 (Controller 레이어에서 권한 검증)
+     *
+     * @param clientId 조회 대상 거래처 ID
+     * @return 이번달 주문 집계 + 여신 한도/미수금/잔여여신
+     */
+    public OrderTradeSummaryResponse getTradeSummary(Long clientId) {
+        // 1. 거래처 조회 (여신 정보 포함)
+        Client client = clientRepository.findById(clientId)
+                .orElseThrow(() -> new CoreException(ErrorType.CLIENT_NOT_FOUND));
+
+        // 2. 이번달 시작 / 다음달 시작 계산
+        LocalDate today = LocalDate.now();
+        LocalDateTime startOfMonth = today.withDayOfMonth(1).atStartOfDay();
+        LocalDateTime startOfNextMonth = startOfMonth.plusMonths(1);
+
+        // 3. 이번달 주문 집계
+        BigDecimal thisMonthTotal = orderHeaderRepository.sumThisMonthTotalAmount(
+                clientId, startOfMonth, startOfNextMonth
+        );
+        long inProgressCount = orderHeaderRepository.countThisMonthByStatus(
+                clientId, OrderStatus.PENDING, startOfMonth, startOfNextMonth
+        );
+        long completedCount = orderHeaderRepository.countThisMonthByStatus(
+                clientId, OrderStatus.CONFIRMED, startOfMonth, startOfNextMonth
+        );
+
+        // 4. 여신 정보 (null-safe)
+        BigDecimal totalCredit = client.getTotalCredit() != null ? client.getTotalCredit() : BigDecimal.ZERO;
+        BigDecimal usedCredit = client.getUsedCredit() != null ? client.getUsedCredit() : BigDecimal.ZERO;
+        BigDecimal remainingCredit = totalCredit.subtract(usedCredit);
+
+        return OrderTradeSummaryResponse.builder()
+                .thisMonth(OrderTradeSummaryResponse.ThisMonth.builder()
+                        .totalAmount(thisMonthTotal)
+                        .inProgressCount(inProgressCount)
+                        .completedCount(completedCount)
+                        .build())
+                .totalCredit(totalCredit)
+                .usedCredit(usedCredit)
+                .remainingCredit(remainingCredit)
+                .build();
     }
 
 }

--- a/src/main/java/com/monsoon/seedflowplus/infra/security/SecurityConfig.java
+++ b/src/main/java/com/monsoon/seedflowplus/infra/security/SecurityConfig.java
@@ -67,6 +67,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.PATCH, "/api/v1/accounts/clients/*").hasRole("ADMIN")
                         .requestMatchers(HttpMethod.PATCH, "/api/v1/accounts/employees/*").hasRole("ADMIN")
                         .requestMatchers("/api/v1/notes/**").hasAnyRole("SALES_REP", "ADMIN")
+                        .requestMatchers(HttpMethod.GET, "/api/v1/orders/clients/*/trade-summary").hasAnyRole("SALES_REP", "ADMIN")
                         .requestMatchers("/api/v1/scoring/**").hasAnyRole("SALES_REP", "ADMIN")
                         .anyRequest().authenticated())
                 .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);


### PR DESCRIPTION
## 변경 사항
feat(order): 거래처 거래 요약 조회 API 추가

- GET /api/v1/orders/clients/{clientId}/trade-summary 엔드포인트 추가
- 이번달 주문 총액, 진행/완료 건수 집계
- 여신 한도, 미수금, 잔여 여신 조회
- SALES_REP, ADMIN 권한만 접근 가능하도록 시큐리티 설정 추가

## 작업 내용
- [x] 기능 구현
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 테스트 추가/수정
- [ ] 문서 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 변수명 변경)

## 체크리스트
- [x] 중요!! : run했을 때 멈추지 않고 돌아가는가
- [x] Push 전 pull dev 했는가
- [x] 불필요한 코드/주석이 없는가

## 참고 사항(생략 가능)
- 리뷰어가 알면 좋은 내용 (스크린샷, 로그, 설계 설명 등)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 거래 요약 조회 엔드포인트 추가: 클라이언트별 월간 거래 현황(총 거래액, 진행 중인 주문 수, 완료된 주문 수) 및 신용 정보(총 신용액, 사용 중인 신용액, 잔여 신용액)를 조회할 수 있습니다.

## 보안
* SALES_REP 및 ADMIN 역할 사용자에게 거래 요약 API 접근 권한이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->