### PR TITLE
청구서 발급되면 payment -> pending상태로 자동으로 입력되도록 변경

### DIFF
--- a/src/main/java/com/monsoon/seedflowplus/domain/billing/invoice/service/InvoiceService.java
+++ b/src/main/java/com/monsoon/seedflowplus/domain/billing/invoice/service/InvoiceService.java
@@ -9,6 +9,8 @@ import com.monsoon.seedflowplus.domain.account.repository.ClientRepository;
 import com.monsoon.seedflowplus.domain.account.repository.EmployeeRepository;
 import com.monsoon.seedflowplus.domain.account.repository.UserRepository;
 import com.monsoon.seedflowplus.domain.account.entity.User;
+import com.monsoon.seedflowplus.domain.billing.payment.entity.Payment;
+import com.monsoon.seedflowplus.domain.billing.payment.repository.PaymentRepository;
 import com.monsoon.seedflowplus.domain.deal.common.ActionType;
 import com.monsoon.seedflowplus.domain.deal.common.ActorType;
 import com.monsoon.seedflowplus.domain.deal.common.DealStage;
@@ -61,6 +63,7 @@ public class InvoiceService {
     private final DealPipelineFacade dealPipelineFacade;
     private final DealLogQueryService dealLogQueryService;
     private final DealScheduleSyncService dealScheduleSyncService;
+    private final PaymentRepository paymentRepository;
 
     /**
      * 청구서 수동 생성 (영업사원)
@@ -170,6 +173,19 @@ public class InvoiceService {
         invoice.updateAmount(publishTotalAmount);
 
         invoice.publish();
+
+        String paymentCode = generateCode("PAY");
+
+        Payment payment = Payment.create(
+                invoice,
+                invoice.getClient(),
+                invoice.getDeal(),
+                null,          // 아직 결제 안했으니까 method 없음
+                paymentCode
+        );
+
+        paymentRepository.save(payment);
+
         ActorType actorType = resolveActorType(principal);
         Long actorId = resolveActorId(actorType, principal);
         dealPipelineFacade.recordAndSync(

--- a/src/main/java/com/monsoon/seedflowplus/domain/billing/payment/entity/Payment.java
+++ b/src/main/java/com/monsoon/seedflowplus/domain/billing/payment/entity/Payment.java
@@ -64,4 +64,8 @@ public class Payment extends BaseCreateEntity {
     public void complete() {
         this.status = PaymentStatus.COMPLETED;
     }
+
+    public void setPaymentMethod(PaymentMethod paymentMethod) {
+        this.paymentMethod = paymentMethod;
+    }
 }

--- a/src/main/java/com/monsoon/seedflowplus/domain/billing/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/monsoon/seedflowplus/domain/billing/payment/repository/PaymentRepository.java
@@ -16,6 +16,8 @@ public interface PaymentRepository extends JpaRepository<Payment, Long> {
 
     Optional<Payment> findByIdAndClientId(Long id, Long clientId);
 
+    Optional<Payment> findByInvoiceId(Long invoiceId);
+
     // 코드 채번용
     @Query("SELECT MAX(CAST(SUBSTRING(p.paymentCode, LENGTH(:prefix) + 1) AS integer)) " +
             "FROM Payment p WHERE p.paymentCode LIKE CONCAT(:prefix, '%')")

--- a/src/main/java/com/monsoon/seedflowplus/domain/billing/payment/service/PaymentService.java
+++ b/src/main/java/com/monsoon/seedflowplus/domain/billing/payment/service/PaymentService.java
@@ -79,31 +79,16 @@ public class PaymentService {
         }
 
         // 4. 결제 저장 (invoice_id unique 제약으로 중복 결제 DB 레벨 차단 + paymentCode 충돌 재시도)
-        int maxRetries = 3;
-        Payment payment = null;
-        for (int i = 0; i < maxRetries; i++) {
-            try {
-                String paymentCode = generateCode("PAY");
-                payment = Payment.create(invoice, client, invoice.getDeal(), request.getPaymentMethod(), paymentCode);
-                paymentRepository.saveAndFlush(payment);
-                break;
-            } catch (DataIntegrityViolationException e) {
-                if (isInvoiceIdViolation(e)) {
-                    // invoice_id unique 위반 = 이미 결제된 청구서
-                    throw new CoreException(ErrorType.ALREADY_PAID);
-                }
-                if (!isPaymentCodeViolation(e)) throw e;
-                if (i == maxRetries - 1) throw new CoreException(ErrorType.PAYMENT_CODE_OVERFLOW);
-                // paymentCode 충돌만 재시도
-            }
+        Payment payment = paymentRepository.findByInvoiceId(invoice.getId())
+                .orElseThrow(() -> new CoreException(ErrorType.PAYMENT_NOT_FOUND));
+
+        // 이미 결제된 경우 차단
+        if (payment.getStatus() == PaymentStatus.COMPLETED) {
+            throw new CoreException(ErrorType.ALREADY_PAID);
         }
 
-        dealPipelineFacade.validateTransitionOrThrow(
-                DealType.PAY,
-                PaymentStatus.PENDING.name(),
-                ActionType.PAY,
-                PaymentStatus.COMPLETED.name()
-        );
+        // 결제 수단 설정
+        payment.setPaymentMethod(request.getPaymentMethod());
 
         payment.complete();
 


### PR DESCRIPTION
## 변경 사항
- 청구서 발행되면 payment테이블에 pending상태로 자동으로 칼럼 들어가는 로직 추가

## 작업 내용
- [ ] 기능 구현
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 테스트 추가/수정
- [ ] 문서 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 변수명 변경)

## 체크리스트
- [ ] 중요!! : run했을 때 멈추지 않고 돌아가는가
- [ ] Push 전 pull dev 했는가
- [ ] 불필요한 코드/주석이 없는가

## 참고 사항(생략 가능)
- (로빈) 3/12에 그냥 결제 전까지 payment에 데이터 안쌓이도록 하기로 했는데, 청구서 넣으면 pending상태로 넣는걸로 로직 추가 했습니다. 만약, 원래 하시던대로 작업 완료 하셨으면 이거 pr 안받고 진행하면 됩니다.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 청구서 발행 시 결제 처리 워크플로우 개선
  * 중복 결제 생성 방지
  * 결제 상태 검증 강화로 이미 처리된 결제 재처리 방지

* **리팩토링**
  * 결제 조회 및 업데이트 로직 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->